### PR TITLE
Do not hijack all well-known URIs

### DIFF
--- a/dockergen/nginx.tmpl
+++ b/dockergen/nginx.tmpl
@@ -125,8 +125,8 @@ server {
     server_name {{ $host }};
 
     {{ if $.Env.LETSENCRYPT_EMAIL }}
-    location /.well-known/ {
-        root /ssl/webroot/{{ $host }};
+    location /.well-known/acme-challenge/ {
+        root /ssl/webroot/{{ $host }}/acme-challenge;
     }
     {{ end }}
 
@@ -162,8 +162,8 @@ server {
     access_log /var/log/nginx/{{ $host }}_access.log;
 
     {{ if $.Env.LETSENCRYPT_EMAIL }}
-    location /.well-known/ {
-        root /ssl/webroot/{{ $host }};
+    location /.well-known/acme-challenge/ {
+        root /ssl/webroot/{{ $host }}/acme-challenge;
     }
     {{ end }}
 


### PR DESCRIPTION
Only the `acme-challenge` well-known URI is used for the purposes of Lets Encrypt, so [other URIs](https://www.ietf.org/assignments/well-known-uris/well-known-uris.xml) should
not be hijacked as they may be used by the hosted site.