### PR TITLE
Add deterministic network selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ root (`/`) of the container
 HTTP path of the container
 * `VIRTUAL_PORT` – if container exposes more than one port, or you do not want to use the default port `80`, you can
 configure a custom port to which a reverse proxy should connect on the container
+* `VIRTUAL_NETWORK` – if container is connected to more than one network, this variable can be used to select which
+network should be used (by default, the first network is used, but the order is not guaranteed)
 * `VIRTUAL_LETSENCRYPT` – if set, this image will automatically generate and enable a SSL key for the virtual host
 using [Let's encrypt](https://letsencrypt.org/) service, if [Let's encrypt feature is enabled](#lets-encrypt)
 

--- a/dockergen/nginx.tmpl
+++ b/dockergen/nginx.tmpl
@@ -7,7 +7,8 @@ upstream {{ $host }}{{ replace $url "/" "-" -1 }}u {
     {{ range $index, $value := $containers }}
         {{ $addrLen := len $value.Addresses }}
         {{ if $value.Networks }}
-            {{ $network := index $value.Networks 0 }}
+            {{ $network := first (where $value.Networks "Name" $value.Env.VIRTUAL_NETWORK) }}
+            {{ $network := when (not $network) (first $value.Networks) $network }}
             {{/* If only 1 port exposed, use that */}}
             {{ if eq $addrLen 1 }}
                 {{ with $address := index $value.Addresses 0 }}
@@ -66,7 +67,8 @@ upstream {{ $host }}{{ replace $alias "/" "-" -1 }}a {
     {{ range $index, $value := $containers }}
         {{ $addrLen := len $value.Addresses }}
         {{ if $value.Networks }}
-            {{ $network := index $value.Networks 0 }}
+            {{ $network := first (where $value.Networks "Name" $value.Env.VIRTUAL_NETWORK) }}
+            {{ $network := when (not $network) (first $value.Networks) $network }}
             {{/* If only 1 port exposed, use that */}}
             {{ if eq $addrLen 1 }}
                 {{ with $address := index $value.Addresses 0 }}


### PR DESCRIPTION
Without this change, when a container has multiple networks, the order is non-deterministic and this can cause connectivity to randomly break. With this change, containers can now set the `VIRTUAL_NETWORK` environmental variable to select (by name) a specific network that should be used.